### PR TITLE
Add netstandard2.0 target.

### DIFF
--- a/GuerrillaNtp/GuerrillaNtp.csproj
+++ b/GuerrillaNtp/GuerrillaNtp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.5</TargetFramework>
+    <TargetFrameworks>netstandard1.5;netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackageVersion>1.4.1.0</PackageVersion>
     <Authors>Robert Važan</Authors>
@@ -12,11 +12,7 @@
     <Description>Simple NTP (SNTP) client that can be embedded in desktop applications to provide them with accurate network time even when the system clock is unsynchronized.</Description>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DocumentationFile>bin\Debug\netstandard1.5\GuerrillaNtp.xml</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType></DebugType>
-    <DocumentationFile>bin\Release\netstandard1.5\GuerrillaNtp.xml</DocumentationFile>
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Hi,

According to [this document](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting), Microsoft's current recommendation is to always include a `netstandard2.0` target, even if a `netstandard1.x` target is still present/required.

> DO include a netstandard2.0 target if you require a netstandard1.x target. All platforms supporting .NET Standard 2.0 will use the netstandard2.0 target and benefit from having a smaller package graph while older platforms will still work and fall back to using the netstandard1.x target.

Targeting `netstandard2.0` will simplify the dependency graph.

This pull request adds a `netstandard2.0` target, while still retaining the initial `netstandard1.5` target.

Thanks!